### PR TITLE
corrected mentor logic in teams table to display mentor name

### DIFF
--- a/app/views/teams/_teams_table_body.html.erb
+++ b/app/views/teams/_teams_table_body.html.erb
@@ -20,8 +20,8 @@
       <td><%= team.participants.map(&:user_email).join(', ') %></td>
 
       <!-- Mentor Name -->
-      <% mentor = team.participants.find { |participant| participant.authorization == 'mentor'} || '--' %>
-      <td><%= mentor.is_a?(Participant) ? mentor.user.name : mentor %></td>
+      <% mentor = team.participants.find { |participant| participant.can_mentor } %>
+      <td><%= mentor ? mentor.user.name : '--' %></td>
 
       <!-- Meeting Dates -->
       <% meeting_dates = Meeting.where(team_id: team.id).order(:date).limit(3).pluck(:date) %>


### PR DESCRIPTION
corrected mentor logic in teams table to display mentor name based on can_mentor status