### PR TITLE
Assign Mentors to Topic manually without Form

### DIFF
--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -278,6 +278,44 @@ class SignUpSheetController < ApplicationController
     redirect_to controller: 'assignments', action: 'edit', id: params[:assignment_id]
   end
 
+  def assign_mentor_to_topic
+    @assignment_id = params[:assignment_id]
+    @topic_id = params[:topic_id]
+    render 'sign_up_sheet/add_mentor_to_topic'
+  end
+
+  def assign_mentor_to_topic_action
+    user = User.find_by(name: params[:username])
+    if user.nil?
+      flash[:error] = 'That user does not exist!'
+      # Redirect here on failure as well to avoid trying to redirect later
+      redirect_to controller: 'assignments', action: 'edit', id: params[:assignment_id] # Assuming assignment_id is always present
+    else
+      topic = SignUpTopic.find_by(id: params[:topic_id])
+      if topic
+        # Directly update only the mentor_id
+        if topic.update(mentor_id: user.id)
+          flash[:success] = 'Mentor successfully assigned to the topic!'
+          ExpertizaLogger.info LoggerMessage.new(controller_name, '', "Mentor #{user.name} assigned to topic: #{params[:topic_id]}")
+          # Redirect on success
+          redirect_to controller: 'assignments', action: 'edit', id: params[:assignment_id] # Assuming assignment_id is present in params
+        else
+          # Handle potential validation errors during save, although unlikely for just mentor_id
+          flash[:error] = "Failed to assign mentor: #{topic.errors.full_messages.join(', ')}"
+          # Redirect on failure
+          redirect_to controller: 'assignments', action: 'edit', id: params[:assignment_id]
+        end
+      else
+        flash[:error] = 'Invalid topic!'
+        ExpertizaLogger.info LoggerMessage.new(controller_name, '', "Invalid topic: #{params[:topic_id]}")
+        # Redirect on failure
+        redirect_to controller: 'assignments', action: 'edit', id: params[:assignment_id] # Assuming assignment_id is always present
+      end
+    end
+    # Removed the final redirect_to as it's handled within the conditional blocks now.
+  end
+
+
   # this function is used to delete a previous signup
   def delete_signup
     participant = AssignmentParticipant.find(params[:id])
@@ -502,7 +540,9 @@ class SignUpSheetController < ApplicationController
     topic.category = params[:topic][:category]
     # topic.assignment_id = params[:id]
     topic.save
-    redirect_to_sign_up(params[:id])
+    if params[:assignment_id].nil?
+      redirect_to_sign_up(params[:id])
+    end
   end
 
   def update_max_choosers(topic)
@@ -510,13 +550,29 @@ class SignUpSheetController < ApplicationController
     # topic and are on waitlist, then they have to be converted to confirmed topic based on the availability. But if
     # there are choosers already and if there is an attempt to decrease the max choosers, as of now I am not allowing
     # it.
-    if SignedUpTeam.find_by(topic_id: topic.id).nil? || topic.max_choosers == params[:topic][:max_choosers]
-      topic.max_choosers = params[:topic][:max_choosers]
-    elsif topic.max_choosers.to_i < params[:topic][:max_choosers].to_i
-      topic.update_waitlisted_users params[:topic][:max_choosers]
-      topic.max_choosers = params[:topic][:max_choosers]
-    else
-      flash[:error] = 'The value of the maximum number of choosers can only be increased! No change has been made to maximum choosers.'
+
+    # *** Add a check to ensure max_choosers is provided before proceeding ***
+    unless params[:topic].key?(:max_choosers)
+      # If max_choosers wasn't passed in params[:topic], don't try to update it.
+      return
+    end
+
+    # Prevent errors if nil or empty string is passed
+    new_max_choosers_str = params[:topic][:max_choosers]
+    return if new_max_choosers_str.blank?
+    new_max_choosers = new_max_choosers_str.to_i
+    current_max_choosers = topic.max_choosers.to_i # Use to_i for consistent comparison
+
+
+    if SignedUpTeam.find_by(topic_id: topic.id).nil? || current_max_choosers == new_max_choosers
+      topic.max_choosers = new_max_choosers
+    elsif current_max_choosers < new_max_choosers
+      # Assuming update_waitlisted_users takes the integer value
+      topic.update_waitlisted_users(new_max_choosers)
+      topic.max_choosers = new_max_choosers
+      # Removed the confusing elsif topic.mentor_id != nil check
+    else # This means: teams exist AND new value <= current value
+      flash[:error] = 'The value of the maximum number of choosers can only be increased when teams are signed up! No change has been made to maximum choosers.'
     end
   end
 

--- a/app/views/sign_up_sheet/_table_line.html.erb
+++ b/app/views/sign_up_sheet/_table_line.html.erb
@@ -52,6 +52,7 @@
     <% end %>
   <% else %>
     --
+    <%= link_to image_tag('/assets/tree_view/add-participant-24.png', :border => 0, :title => 'Assign Mentor', :align => 'middle'), assign_mentor_to_topic_sign_up_sheet_index_path( assignment_id: params[:id], topic_id: topic.id) %>
   <% end %>
 </td>
 

--- a/app/views/sign_up_sheet/add_mentor_to_topic.html.erb
+++ b/app/views/sign_up_sheet/add_mentor_to_topic.html.erb
@@ -1,0 +1,7 @@
+<%= form_tag(:controller => "sign_up_sheet", :action => "assign_mentor_to_topic_action",:topic_id => params[:topic_id], :assignment_id => params[:assignment_id]) do %>
+  <%= label_tag(:username, "Add Mentor to this topic:") %>
+  <%= text_field_tag(:username) %>
+  <%= hidden_field_tag "topic_id", params[:topic_id] %>
+  <%= hidden_field_tag "assignment_id", params[:assignment_id] %>
+  <%= submit_tag("Submit") %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Expertiza::Application.routes.draw do
 
     member do
       get :unassign_mentor
+      get :assign_mentor
     end
   end
 
@@ -428,9 +429,12 @@ Expertiza::Application.routes.draw do
       get :intelligent_sign_up
       get :intelligent_save
       get :signup_as_instructor
+      get :assign_mentor_to_topic
       get :delete_signup_as_instructor
+      get :update_existing_topic
       post :delete_all_topics_for_assignment
       post :signup_as_instructor_action
+      post :assign_mentor_to_topic_action
       post :set_priority
       post :save_topic_deadlines
       post :delete_all_selected_topics


### PR DESCRIPTION

adds a button on the topic tab for each topic to add a mentor to the topic if one is not already there